### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,6 @@ steps:
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
 - script: |
-    python -m twine upload -r pypi --config-file ${PYPIRC_PATH} dist/*
+    python -m twine upload --skip-existing -r pypi --config-file ${PYPIRC_PATH} dist/*
   displayName: 'Publish artifacts'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
adding skip-existing to try to remove the failure when only updating packages using renovate bot.